### PR TITLE
Add managed field

### DIFF
--- a/cloudflare.py
+++ b/cloudflare.py
@@ -287,7 +287,7 @@ class Zone(object):
         return map(lambda record: record_from_dict(record.copy()), self.records)
 
     def diff(self):
-        existing_tuples = {(record.type, record.name, record.content): record for record in self.existing()}
+         existing_tuples = {(record.type, record.name, record.content, record.managed): record for record in self.existing()}
         desired_tuples = {(record.type, record.name, record.content, record.managed): record for record in self.desired()}
 
         changes = []


### PR DESCRIPTION
Note: DO NOT MERGE AS IS.

It would be nice to have a flag that would allow a user to designate that a record is going to be managed outside of Salt - this would take care of dynamically updated records, for example.

I believe I got most of the work done, but the piece I am missing is the  self.ACTION_REMOVE function. I couldn't think of a clever way to check for a given existing record if there is a desired record that has the managed flag set. Currently it will see that the records differ, and remove it, but will not re-add the managed=false records.

Any ideas?