### PR TITLE
Add managed field, part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Each record can have the following fields:
 * `type`    - type of the record: `A`, `AAAA`, `SRV`, etc (`A` by default)
 * `proxied` - whether zone should be proxied (`false` by default)
 * `ttl`     - TTL of the record in seconds, `1` means auto" (`1` by default)
+* `managed` - whether the record will be managed by Salt (`true` by default)
 
 Reference: https://api.cloudflare.com/#dns-records-for-a-zone-properties
 

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -287,8 +287,9 @@ class Zone(object):
         return map(lambda record: record_from_dict(record.copy()), self.records)
 
     def diff(self):
-        existing_tuples = {(record.type, record.name, record.content): record for record in self.existing()}
+        existing_tuples = {(record.type, record.name, record.content, recrod.managed): record for record in self.existing()}
         desired_tuples = {(record.type, record.name, record.content, record.managed): record for record in self.desired()}
+        desired_managed = {record.name: record.managed for record in self.desired()}
 
         changes = []
 
@@ -301,6 +302,8 @@ class Zone(object):
             })
 
         for key in set(existing_tuples).difference(desired_tuples):
+            if key[1] in desired_managed and desired_managed[key[1]] == False:
+                continue
             changes.append({
                 "action": self.ACTION_REMOVE,
                 "record": existing_tuples[key],

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -294,7 +294,7 @@ class Zone(object):
         changes = []
 
         for key in set(desired_tuples).difference(existing_tuples):
-            if desired_tuples[key].managed == False:
+            if not desired_tuples[key].managed:
                 continue
             changes.append({
                 "action": self.ACTION_ADD,

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -310,7 +310,7 @@ class Zone(object):
             })
 
         for key in set(existing_tuples).intersection(desired_tuples):
-            if (existing_tuples[key].pure() == desired_tuples[key]) or (desired_tuples[key].managed == False):
+            if existing_tuples[key].pure() == desired_tuples[key] or not desired_tuples[key].managed:
                 continue
             changes.append({
                 "action": self.ACTION_UPDATE,


### PR DESCRIPTION
A follow up to @liftedkilt's PR #5 - adds a `managed` field for each record, and won't add, update, or remove an existing record if the field is set to false.

One situation where this is useful is with [ArgoTunnel](https://www.cloudflare.com/products/argo-tunnel/), which will create a CNAME record that you wouldn't want your Salt configs to overwrite or remove.  