### PR TITLE
Added support for CAA records

### DIFF
--- a/cloudflare.py
+++ b/cloudflare.py
@@ -136,6 +136,15 @@ class Record(namedtuple("Record", ("id", "type", "name", "content", "proxied", "
                 "port": int(port),
                 "target": target,
             }
+        if self.type == "CAA":
+            parts = self.content.split("\t")
+            flags, tag, value = parts
+            return {
+                "name": self.name,
+                "flags": int(flags),
+                "tag": tag,
+                "value": value[1:-1],
+            }
 
     def __str__(self):
         ttl_str = 'auto' if self.ttl == 1 else '{0}s'.format(self.ttl)


### PR DESCRIPTION
This PR adds support for CAA records (https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
The content of a CAA record is specified as shown below.
Take care to use a tab to separate each component: flags, tag and value.
The value component requires quotes around. They are not optional.

```
cloudflare_zones:
  example.com:
    records:
      - name: example.com
        type: CAA
        content: '0	issue	"letsencrypt.org"'
```