### PR TITLE
Fix for CAA Records

### DIFF
--- a/cloudflare.py
+++ b/cloudflare.py
@@ -187,7 +187,7 @@ class Record(
                 "target": target,
             }
         if self.type == "CAA":
-            parts = self.content.split("\t")
+            parts = self.content.split(" ")
             flags, tag, value = parts
             return {
                 "name": self.name,


### PR DESCRIPTION
The API returns the data as space separated, not tab separated.