### PR TITLE
fixes __str__ method to return string as intended

### DIFF
--- a/cloudflare.py
+++ b/cloudflare.py
@@ -199,7 +199,7 @@ class Record(
     def __str__(self):
         ttl_str = 'auto' if self.ttl == 1 else '{0}s'.format(self.ttl)
         priority_string = 'priority: {0}, '.format(self.priority) if self.type == "MX" else ''
-        return "{0} {1} -> '{2}' (proxied: {3}, ttl: {4})".format(
+        return "{0} {1} -> '{2}' ({3}proxied: {4}, ttl: {5})".format(
             self.type, self.name, self.content, priority_string, str(self.proxied).lower(), ttl_str
         )
 


### PR DESCRIPTION
Fixes the __str__ method to output the values in the intended way. 

Fix to this commit that introduced mx priority support: 

https://github.com/cloudflare/salt-cloudflare/commit/1e57a2aeb02e10bd9518b550648edcbb197d1a6f